### PR TITLE
feat: Ollama推論バックエンドのサポートを追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import argparse
 from src.funs import setup_pipeline
 
 def main():
+    parser = argparse.ArgumentParser(description="Synthetic Data Generation Pipeline")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="settings.yaml",
+        help="Path to the settings YAML file."
+    )
+    args = parser.parse_args()
+
     # パイプライン初期化
-    pipe = setup_pipeline("settings.yaml")
+    pipe = setup_pipeline(args.config)
 
     try:
         # 質問生成

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ seaborn==0.13.2
 
 wordfreq[ja]==3.1.1
 fugashi[unidic-lite]==1.5.1
+ollama

--- a/settings_ollama.yaml
+++ b/settings_ollama.yaml
@@ -1,0 +1,67 @@
+# --- 全体の設定
+# 推論バックエンドを選択: "vllm" または "ollama"
+inference_backend: "ollama"
+
+# --- Ollamaの設定
+# Ollamaでpullしたモデル名（例: "gemma3:1b", "llama3"）を指定してください。
+Instruct_model_name: "gemma3:1b"
+Instruct_temperature: 0.7
+Instruct_top_p: 0.6
+
+base_model_name: "qwen3:1.7b"
+base_temperature: 0.65
+base_top_p: 0.6
+
+think_model_name: "deepseek-r1:1.5b"
+think_temperature: 0.65
+think_top_p: 0.6
+
+# --- vLLMと互換性のためのダミー設定 (Ollamaでは使用されません)
+Instruct_model_quantization: null
+Instruct_gpu_memory_utilization: 0.9
+Instruct_dtype: "auto"
+base_model_quantization: null
+base_gpu_memory_utilization: 0.7
+base_dtype: "auto"
+think_model_quantization: null
+think_gpu_memory_utilization: 0.9
+think_dtype: "auto"
+tensor_parallel_size: 1
+trust_remote_code: True
+
+# --- 共通設定
+batch_size: 8 # OllamaはvLLMより遅い場合が多いため、バッチサイズを小さめに設定することを推奨
+max_tokens: 4096
+seed: 42
+
+# --- データやモデルの配置設定
+# Ollamaで埋め込みに使用するモデル名
+E5_model_name: "mxbai-embed-large"
+# ローカルE5モデルのパス（vLLMモードとの互換性のためのダミー）
+E5_path: "./data/model/multilingual-e5-large"
+
+# --- 質問データ生成パイプラインの設定
+Seed_generation_method: "inst"
+Prompt_evolution: False
+Prompt_evolution_times: 0
+Number_of_stages_of_prompt_evolution: False
+Data_retention_rate_after_diversity_cut: 50
+
+# --- 回答データ生成パイプラインの設定
+Answer_evolution: False
+Answer_evolution_times: 0
+Number_of_stages_of_answer_evolution: False
+
+# --- 長考モデルの回答の設定
+Using_think_models_for_answer: False
+Thinking_separation_evolution: False
+Number_of_thought_evolutions: 1
+
+# --- 回答データキュレーションの設定
+Data_curation: False
+
+# --- 出力先などに関する設定
+data_folda_path: "./data"
+Save_temporary_data: True
+Number_of_questions_generated: 50
+output_path: "./data"

--- a/src/e5.py
+++ b/src/e5.py
@@ -1,38 +1,21 @@
 import numpy as np
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
-from typing import List, Dict, Union, Optional
-
-# --- 設定 ---
-# 注意: このモデルパスは、ローカル環境にモデルが存在する場合のパスです。
-# 存在しない場合は、Hugging Face Hubのモデル名（例: 'intfloat/multilingual-e5-large'）
-# を指定すると、自動的にダウンロードされます。
-DEFAULT_MODEL_PATH = 'intfloat/multilingual-e5-large'
-
+from typing import List, Dict, Union, Optional, Any
+import ollama
+import sys
+from ollama import ResponseError
 
 def reduce_data_by_diversity(
     data: Union[List[str], List[Dict]],
     data_format: str,
     cut_rate: float,
+    settings: Any,
     data_key: Optional[str] = None,
-    model_path: str = DEFAULT_MODEL_PATH
 ) -> Union[List[str], List[Dict]]:
     """
     データの多様性に基づいて、類似度の高いデータから指定された割合を削減する関数。
-
-    Args:
-        data (Union[List[str], List[Dict]]): 削減対象のデータ。
-        data_format (str): データの形式。"list"または"dict"を指定。
-        cut_rate (float): 削減するデータの割合（0〜100）。
-        data_key (Optional[str], optional): data_formatが"dict"の場合、
-                                            処理対象のテキストが含まれるキー。
-                                            Defaults to None.
-        model_path (str, optional): 使用するSentenceTransformerモデルのパスまたは
-                                    Hugging Face Hubのモデル名。
-                                    Defaults to DEFAULT_MODEL_PATH.
-
-    Returns:
-        Union[List[str], List[Dict]]: 削減後のデータ。
+    推論バックエンドの設定に応じて、OllamaまたはローカルのSentenceTransformerを使い分ける。
     """
     # --- 1. 入力値の検証 ---
     if not (0 <= cut_rate <= 100):
@@ -62,35 +45,67 @@ def reduce_data_by_diversity(
     if num_to_cut >= len(sentences):
         return []
 
-    # --- 4. モデルの読み込みと文章のエンコード ---
-    print(f"モデル '{model_path}' を読み込んでいます...")
-    try:
-        model = SentenceTransformer(model_path)
-    except Exception as e:
-        raise RuntimeError(f"モデル '{model_path}' の読み込みに失敗しました。パスが正しいか確認してください。エラー: {e}")
+    # --- 4. バックエンドに応じてエンコード処理を分岐 ---
+    backend = getattr(settings, 'inference_backend', 'vllm')
+    embeddings = None
 
-    print("文章のベクトル化（エンコード）を実行中...")
-    # 参考コードと同様に、検索タスク用のプレフィックスを付与
-    embeddings = model.encode(['passage: ' + s for s in sentences], show_progress_bar=False)
+    if backend == 'ollama':
+        model_name = getattr(settings, 'E5_model_name', 'mxbai-embed-large')
+        print(f"Ollama埋め込みモデル '{model_name}' を使用してベクトルを生成します。")
+        try:
+            # Ollamaはリストで一括処理できる
+            response = ollama.embed(model=model_name, input=sentences)
+            
+            # responseオブジェクトからembeddings属性を取得しようと試みる
+            embedding_list = getattr(response, 'embeddings', None)
+
+            # 古いライブラリとの後方互換性のため、辞書形式もチェック
+            if embedding_list is None and isinstance(response, dict) and 'embeddings' in response:
+                embedding_list = response['embeddings']
+
+            if embedding_list:
+                embeddings = np.array(embedding_list)
+            else:
+                print(f"Ollamaからの予期せぬレスポンス形式です: {response}")
+                sys.exit(1)
+        except ResponseError as e:
+            print(f"Ollamaでの埋め込み生成中にエラーが発生しました: {e.error}")
+            if e.status_code == 404:
+                print(f"エラー: 埋め込みモデル '{model_name}' が見つかりません。")
+                print(f"解決策: 'ollama pull {model_name}' を実行してモデルをダウンロードしてください。")
+                sys.exit(1)
+            sys.exit(1)
+        except Exception as e:
+            print(f"予期せぬエラーが発生しました: {e}")
+            sys.exit(1)
+    else: # vLLM or default
+        model_path = settings.E5_path
+        print(f"モデル '{model_path}' を読み込んでいます...")
+        try:
+            model = SentenceTransformer(model_path)
+            # 参考コードと同様に、検索タスク用のプレフィックスを付与
+            embeddings = model.encode(['passage: ' + s for s in sentences], show_progress_bar=False)
+        except Exception as e:
+            print(f"モデル '{model_path}' の読み込みに失敗しました。パスが正しいか確認してください。エラー: {e}")
+            # エラーが発生した場合、多様性フィルタをスキップして元のデータを返す
+            return data
 
     # --- 5. 類似度に基づいて削減対象を選定 ---
-    print("類似度を計算し、削減対象を選定中...")
-    # コサイン類似度を計算
-    similarity_matrix = cosine_similarity(embeddings)
+    if embeddings is not None:
+        print("類似度を計算し、削減対象を選定中...")
+        similarity_matrix = cosine_similarity(embeddings)
+        np.fill_diagonal(similarity_matrix, -1)
+        redundancy_scores = np.max(similarity_matrix, axis=1)
+        indices_to_cut = np.argsort(-redundancy_scores)[:num_to_cut]
+        indices_to_cut_set = set(indices_to_cut)
 
-    # 各データについて、自身を除く他のデータとの最大類似度を求める
-    # 対角成分（自身との類似度=1.0）を計算から除外するために-1で埋める
-    np.fill_diagonal(similarity_matrix, -1)
-    # 各行の最大値が「最も似ているデータとの類似度スコア」になる
-    redundancy_scores = np.max(similarity_matrix, axis=1)
+        # --- 6. 削減後のデータを生成 ---
+        reduced_data = [item for i, item in enumerate(data) if i not in indices_to_cut_set]
+        
+        print(f"処理が完了しました。{len(data)}件のデータから{len(indices_to_cut)}件を削減し、{len(reduced_data)}件になりました。")
+        return reduced_data
+    else:
+        # エンべディングが生成されなかった場合は元のデータを返す
+        print("警告: エンべディングが生成されなかったため、多様性フィルタリングをスキップしました。")
+        return data
 
-    # 冗長性スコアが高い順にインデックスをソートし、削減対象を取得
-    # np.argsortは昇順で返すため、スコアを負にして降順ソートと同じ効果を得る
-    indices_to_cut = np.argsort(-redundancy_scores)[:num_to_cut]
-    indices_to_cut_set = set(indices_to_cut)
-
-    # --- 6. 削減後のデータを生成 ---
-    reduced_data = [item for i, item in enumerate(data) if i not in indices_to_cut_set]
-    
-    print(f"処理が完了しました。{len(data)}件のデータから{len(indices_to_cut)}件を削減し、{len(reduced_data)}件になりました。")
-    return reduced_data

--- a/src/ollama_inf.py
+++ b/src/ollama_inf.py
@@ -1,0 +1,134 @@
+import ollama
+import sys
+from typing import List, Any
+from ollama import ResponseError
+
+# --- ヘルパー関数 -----------------------------------------------------------------
+
+def _get_model_name(settings: Any, prefix: str) -> str:
+    """
+    settingsオブジェクトとプレフィックスに基づき、モデル名を取得する。
+    """
+    return getattr(settings, f"{prefix}_model_name")
+
+def _get_sampling_params(settings: Any, prefix: str) -> dict:
+    """
+    settingsオブジェクトとプレフィックスに基づき、Ollama用のサンプリングパラメータを生成する。
+    """
+    temperature = getattr(settings, f"{prefix}_temperature", 0.7)
+    top_p = getattr(settings, f"{prefix}_top_p", 0.9)
+    max_tokens = getattr(settings, "max_tokens", 4096)
+    seed = getattr(settings, "seed", 42)
+    
+    return {
+        "temperature": temperature,
+        "top_p": top_p,
+        "num_predict": max_tokens,
+        "seed": seed,
+    }
+
+def _execute_inference(model_name: str, prompts: List[str], options: dict, is_chat: bool) -> List[str]:
+    """
+    Ollamaを使用して推論を実行する内部関数。
+    """
+    print(f"Ollamaモデル '{model_name}' を使用して{len(prompts)}件の推論を実行中...")
+    results = []
+    try:
+        for prompt in prompts:
+            if is_chat:
+                response = ollama.chat(
+                    model=model_name,
+                    messages=[{'role': 'user', 'content': prompt}],
+                    options=options
+                )
+                results.append(response['message']['content'])
+            else:
+                response = ollama.generate(
+                    model=model_name,
+                    prompt=prompt,
+                    options=options
+                )
+                results.append(response['response'])
+        print("推論が完了しました。")
+        return results
+    except ResponseError as e:
+        print(f"Ollamaでの推論中にエラーが発生しました: {e.error}")
+        if e.status_code == 404:
+            print(f"エラー: モデル '{model_name}' が見つかりません。")
+            print(f"解決策: 'ollama pull {model_name}' を実行してモデルをダウンロードしてください。")
+            sys.exit(1)
+        return [""] * len(prompts)
+    except Exception as e:
+        print(f"予期せぬエラーが発生しました: {e}")
+        sys.exit(1)
+
+# --- 1. モデルロード/アンロード系関数（ダミー） --------------------------------------------------
+# Ollamaではクライアント側での明示的なロード/アンロードは不要なため、ダミー関数を定義します。
+
+def inst_model_load(settings: Any) -> str:
+    model_name = _get_model_name(settings, "Instruct")
+    print(f"Ollamaモデル '{model_name}' を使用します。")
+    return model_name
+
+def base_model_load(settings: Any) -> str:
+    model_name = _get_model_name(settings, "base")
+    print(f"Ollamaモデル '{model_name}' を使用します。")
+    return model_name
+
+def think_model_load(settings: Any) -> str:
+    model_name = _get_model_name(settings, "think")
+    print(f"Ollamaモデル '{model_name}' を使用します。")
+    return model_name
+
+def unload_model(model_path_for_log: str):
+    print(f"Ollamaモデル '{model_path_for_log}' のセッションを終了しました。")
+    pass
+
+# --- 2. 推論系関数（5種類） ------------------------------------------------------
+
+def inst_model_inference(llm: str, prompts: List[str], settings: Any) -> List[str]:
+    """
+    Instructモデル（チャット形式）を用いてバッチ推論を行う。
+    """
+    model_name = llm
+    options = _get_sampling_params(settings, "Instruct")
+    return _execute_inference(model_name, prompts, options, is_chat=True)
+
+def base_model_inference(llm: str, prompts: List[str], settings: Any) -> List[str]:
+    """
+    ベースモデル（生成形式）を用いてバッチ推論を行う。
+    """
+    model_name = llm
+    options = _get_sampling_params(settings, "base")
+    options["stop"] = ['<stop>']
+    return _execute_inference(model_name, prompts, options, is_chat=False)
+
+def think_model_inference(llm: str, prompts: List[str], settings: Any) -> List[str]:
+    """
+    長考モデル（チャット形式）を用いてバッチ推論を行う。
+    """
+    model_name = llm
+    options = _get_sampling_params(settings, "think")
+    return _execute_inference(model_name, prompts, options, is_chat=True)
+
+def curation_model_inference(llm: str, prompts: List[str], settings: Any) -> List[str]:
+    """
+    キュレーション用の推論を行う。ベースモデルを使用するが、サンプリングパラメータが異なる。
+    """
+    model_name = llm
+    options = _get_sampling_params(settings, "base")
+    options["temperature"] = 0.01
+    options["top_p"] = 1.0
+    options["stop"] = ['<stop>']
+    return _execute_inference(model_name, prompts, options, is_chat=False)
+
+def evolution_model_inference(llm: str, prompts: List[str], settings: Any) -> List[str]:
+    """
+    思考を進化させるための推論を行う。ベースモデルを使用するが、サンプリングパラメータが異なる。
+    """
+    model_name = llm
+    options = _get_sampling_params(settings, "base")
+    options["temperature"] = 0.6
+    options["top_p"] = 0.9
+    options["stop"] = ['<stop>']
+    return _execute_inference(model_name, prompts, options, is_chat=False)


### PR DESCRIPTION
Ollamaを推論バックエンドとして利用する機能を追加しました。
これにより、vLLMに加えてOllama経由でモデルを利用してデータ生成パイプラインを実行できるようになります。

主な変更点:
- `inference_backend` 設定 (`vllm` または `ollama`) に基づいて、推論モジュールを動的に切り替えるようにリファクタリング
- Ollamaライブラリを利用した推論処理を実装 (`src/ollama_inf.py`)
- 多様性フィルタリング (`src/e5.py`) でOllamaの埋め込みモデルをサポート
- 設定ファイルをコマンドライン引数で指定可能に (`main.py`)
- Ollama用の設定ファイル例を追加 (`settings_ollama.yaml`)

## 動作確認方法

`python main.py --config settings_ollama.yaml`